### PR TITLE
Remove hyphen from storage account name

### DIFF
--- a/solutions/lamp-stack-vm-v1/azuredeploy.json
+++ b/solutions/lamp-stack-vm-v1/azuredeploy.json
@@ -1566,7 +1566,7 @@
             "sshPublicKey": "[parameters('sshPublicKey')]",
             "sshUsername": "[parameters('sshUsername')]",
             "sslEnforcement": "[parameters('sslEnforcement')]",
-            "storageAccountName": "[tolower(variables('resourceprefix'))]",
+            "storageAccountName": "[tolower(concat(parameters('_resourceNamePrefix') , substring(uniqueString(resourceGroup().id, deployment().name), 3, 6), 'sa'))]",
             "storageAccountType": "[parameters('storageAccountType')]",
             "subnetAppGw": "[concat('appgw-subnet-',variables('resourceprefix'))]",
             "subnetAppGwPrefix": "[concat(variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),6)))]",

--- a/solutions/wordpress-azure-vm-v1/azuredeploy.json
+++ b/solutions/wordpress-azure-vm-v1/azuredeploy.json
@@ -1566,7 +1566,7 @@
             "sshPublicKey": "[parameters('sshPublicKey')]",
             "sshUsername": "[parameters('sshUsername')]",
             "sslEnforcement": "[parameters('sslEnforcement')]",
-            "storageAccountName": "[tolower(variables('resourceprefix'))]",
+            "storageAccountName": "[tolower(concat(parameters('_resourceNamePrefix') , substring(uniqueString(resourceGroup().id, deployment().name), 3, 6), 'sa'))]",
             "storageAccountType": "[parameters('storageAccountType')]",
             "subnetAppGw": "[concat('appgw-subnet-',variables('resourceprefix'))]",
             "subnetAppGwPrefix": "[concat(variables('octets')[0], '.', variables('octets')[1], '.', string(add(int(variables('octets')[2]),6)))]",


### PR DESCRIPTION
The hyphen in the resourceNamePrefix was causing template errors, so this PR will remove the hyphen from the storage account name by simply concatenating only the resourceName and partial hash without the hyphen