### PR TITLE
Change Arc VM and AVS VM Create blade to ReactView

### DIFF
--- a/solutiongroups/defaultLandingVmBrowse.json
+++ b/solutiongroups/defaultLandingVmBrowse.json
@@ -19,7 +19,7 @@
             },
             "bladeReference": {
                 "extension": "Microsoft_Azure_HybridCompute",
-                "bladeName": "ArcVmCreateBlade",
+                "bladeName": "ArcVmCreate.ReactView",
                 "inputs": {}
             }
         },
@@ -33,9 +33,9 @@
             },
             "bladeReference": {
                 "extension": "Microsoft_Azure_HybridCompute",
-                "bladeName": "ArcVmCreateBlade",
+                "bladeName": "ArcVmCreate.ReactView",
                 "inputs": {
-                    "vmKindFilter": "microsoft.avs"
+                    "vmKind": "microsoft.avs"
                 }
             }
         },


### PR DESCRIPTION
Modify Azure Arc VM and AVS VM solutions to point to the new Create blade. We migrated the Create blade from KO to ReactView for improved performance.