### PR TITLE
Rolled back references to ArcVmCreate.ReactView to previous KO version

### DIFF
--- a/solutiongroups/defaultLandingVmBrowse.json
+++ b/solutiongroups/defaultLandingVmBrowse.json
@@ -19,9 +19,8 @@
             },
             "bladeReference": {
                 "extension": "Microsoft_Azure_HybridCompute",
-                "bladeName": "ArcVmCreate.ReactView",
-                "inputs": {},
-                "doesProvisioning": true
+                "bladeName": "ArcVmCreateBlade",
+                "inputs": {}
             }
         },
         {
@@ -34,11 +33,10 @@
             },
             "bladeReference": {
                 "extension": "Microsoft_Azure_HybridCompute",
-                "bladeName": "ArcVmCreate.ReactView",
+                "bladeName": "ArcVmCreateBlade",
                 "inputs": {
-                    "vmKind": "microsoft.avs"
-                },
-                "doesProvisioning": true
+                    "vmKindFilter": "microsoft.avs"
+                }
             }
         },
         {


### PR DESCRIPTION
- Rolled back blade reference from `ArcVmCreate.ReactView` to older KO version `ArcVmCreateBlade` to address the Create Arc VM issues we're seeing