### PR TITLE
Updated Arc Server reference in defaultLandingVmBrowse

### DIFF
--- a/solutiongroups/defaultLandingVmBrowse.json
+++ b/solutiongroups/defaultLandingVmBrowse.json
@@ -58,9 +58,9 @@
                 "iconFileName": "ArcServer"
             },
             "bladeReference": {
-                "extension": "Microsoft_Azure_HybridCompute",
+                "extensionName": "Microsoft_Azure_HybridCompute",
                 "bladeName": "HybridVmAddBlade",
-                "inputs": { }
+                "parameters": {}
             }
         }
     ]


### PR DESCRIPTION
Updated Arc Server reference in `defaultLandingVmBrowse` to rename `extension` to `extensionName` and `inputs` to `parameters`