### PR TITLE
Adding additional workloads for Workloads Handler

### DIFF
--- a/workloads/vm-starter-kit-linux/vm-starter-kit-linux.arm/parameters.json
+++ b/workloads/vm-starter-kit-linux/vm-starter-kit-linux.arm/parameters.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "resourceNamePrefix": {
+            "value": "linux-vm-"
+        },
+        "sshPublicKey": {
+            "value": ""
+        },
+        "location": {
+            "value": "eastus"
+        },
+        "vmSize": {
+            "value": "Standard_DS2_v2"
+        },
+        "adminUsername": {
+            "value": "adminuser"
+        },
+        "adminPassword": {
+            "value": "password123"
+        }
+    }
+}

--- a/workloads/vm-starter-kit-linux/vm-starter-kit-linux.arm/template.json
+++ b/workloads/vm-starter-kit-linux/vm-starter-kit-linux.arm/template.json
@@ -1,0 +1,526 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "location": {
+        "type": "string",
+        "defaultValue": "[resourceGroup().location]"
+      },
+      "bastionName": {
+        "type": "string",
+        "defaultValue": "BastionHost"
+      },
+      "networkName": {
+        "type": "string",
+        "defaultValue": "VmStarterKit"
+      },
+      "vmSubnetName": {
+        "type": "string",
+        "defaultValue": "VMs"
+      },
+      "vmName": {
+        "type": "string",
+        "defaultValue": "vm-01"
+      },
+      "vmSize": {
+        "type": "string",
+        "defaultValue": "Standard_D2s_v5"
+      },
+      "ubuntuOffer": {
+        "type": "string",
+        "defaultValue": "0001-com-ubuntu-server-focal"
+      },
+      "ubuntuSku": {
+        "type": "string",
+        "defaultValue": "20_04-lts-gen2"
+      },
+      "adminUsername": {
+        "type": "string"
+      },
+      "sshPublicKey": {
+        "type": "secureString"
+      },
+      "osdiskSizeGB": {
+        "type": "int",
+        "defaultValue": 30
+      }
+    },
+    "functions": [],
+    "resources": [
+      {
+        "type": "Microsoft.Resources/deployments",
+        "apiVersion": "2019-10-01",
+        "name": "vnet",
+        "properties": {
+          "expressionEvaluationOptions": {
+            "scope": "inner"
+          },
+          "mode": "Incremental",
+          "parameters": {
+            "location": {
+              "value": "[parameters('location')]"
+            },
+            "networkName": {
+              "value": "[parameters('networkName')]"
+            },
+            "vmSubnetName": {
+              "value": "[parameters('vmSubnetName')]"
+            }
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "location": {
+                "type": "string",
+                "defaultValue": "[resourceGroup().location]"
+              },
+              "networkName": {
+                "type": "string"
+              },
+              "vmSubnetName": {
+                "type": "string"
+              },
+              "openWebPorts": {
+                "type": "bool",
+                "defaultValue": false
+              },
+              "logAnalyticsWorkspaceId": {
+                "type": "string",
+                "defaultValue": ""
+              }
+            },
+            "functions": [],
+            "variables": {
+              "vNetName": "[format('vnet-{0}', parameters('networkName'))]",
+              "vNetAddressPrefix": "10.1.0.0/16",
+              "bastionSubnetAddressPrefix": "10.1.0.0/24",
+              "vmSubnetAddressPrefix": "10.1.1.0/24",
+              "nsgName": "[format('nsg-subnet-{0}', parameters('vmSubnetName'))]",
+              "bastionSubnetName": "AzureBastionSubnet"
+            },
+            "resources": [
+              {
+                "type": "Microsoft.Network/networkSecurityGroups",
+                "apiVersion": "2022-07-01",
+                "name": "[variables('nsgName')]",
+                "location": "[parameters('location')]",
+                "properties": {
+                  "securityRules": "[if(equals(parameters('openWebPorts'), false()), createArray(), createArray(createObject('name', 'AllowHttpInbound', 'properties', createObject('protocol', 'Tcp', 'sourcePortRange', '*', 'destinationPortRange', '80', 'sourceAddressPrefix', 'Internet', 'destinationAddressPrefix', '*', 'access', 'Allow', 'priority', 100, 'direction', 'Inbound'))))]"
+                }
+              },
+              {
+                "type": "Microsoft.Network/virtualNetworks",
+                "apiVersion": "2022-07-01",
+                "name": "[variables('vNetName')]",
+                "location": "[parameters('location')]",
+                "properties": {
+                  "addressSpace": {
+                    "addressPrefixes": [
+                      "[variables('vNetAddressPrefix')]"
+                    ]
+                  },
+                  "subnets": [
+                    {
+                      "name": "[variables('bastionSubnetName')]",
+                      "properties": {
+                        "addressPrefix": "[variables('bastionSubnetAddressPrefix')]",
+                        "privateEndpointNetworkPolicies": "Disabled"
+                      }
+                    },
+                    {
+                      "name": "[parameters('vmSubnetName')]",
+                      "properties": {
+                        "addressPrefix": "[variables('vmSubnetAddressPrefix')]",
+                        "privateEndpointNetworkPolicies": "Disabled",
+                        "networkSecurityGroup": {
+                          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgName'))]"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "dependsOn": [
+                  "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgName'))]"
+                ]
+              },
+              {
+                "condition": "[not(empty(parameters('logAnalyticsWorkspaceId')))]",
+                "type": "Microsoft.Insights/diagnosticSettings",
+                "apiVersion": "2021-05-01-preview",
+                "scope": "[format('Microsoft.Network/virtualNetworks/{0}', variables('vNetName'))]",
+                "name": "[format('{0}-diagnosticsettings', variables('vNetName'))]",
+                "properties": {
+                  "logs": [
+                    {
+                      "categoryGroup": "allLogs",
+                      "enabled": true
+                    }
+                  ],
+                  "metrics": [
+                    {
+                      "category": "AllMetrics",
+                      "enabled": true
+                    }
+                  ],
+                  "workspaceId": "[parameters('logAnalyticsWorkspaceId')]"
+                },
+                "dependsOn": [
+                  "[resourceId('Microsoft.Network/virtualNetworks', variables('vNetName'))]"
+                ]
+              },
+              {
+                "condition": "[not(empty(parameters('logAnalyticsWorkspaceId')))]",
+                "type": "Microsoft.Insights/diagnosticSettings",
+                "apiVersion": "2021-05-01-preview",
+                "scope": "[format('Microsoft.Network/networkSecurityGroups/{0}', variables('nsgName'))]",
+                "name": "[format('{0}-diagnosticsettings', variables('nsgName'))]",
+                "properties": {
+                  "logs": [
+                    {
+                      "categoryGroup": "allLogs",
+                      "enabled": true
+                    }
+                  ],
+                  "workspaceId": "[parameters('logAnalyticsWorkspaceId')]"
+                },
+                "dependsOn": [
+                  "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgName'))]"
+                ]
+              }
+            ],
+            "outputs": {
+              "vNetName": {
+                "type": "string",
+                "value": "[variables('vNetName')]"
+              },
+              "bastionSubnetName": {
+                "type": "string",
+                "value": "[variables('bastionSubnetName')]"
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Resources/deployments",
+        "apiVersion": "2019-10-01",
+        "name": "bastion",
+        "properties": {
+          "expressionEvaluationOptions": {
+            "scope": "inner"
+          },
+          "mode": "Incremental",
+          "parameters": {
+            "location": {
+              "value": "[parameters('location')]"
+            },
+            "bastionName": {
+              "value": "[parameters('bastionName')]"
+            },
+            "vNetName": {
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2019-10-01').outputs.vNetName.value]"
+            },
+            "bastionSubnetName": {
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2019-10-01').outputs.bastionSubnetName.value]"
+            }
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "location": {
+                "type": "string",
+                "defaultValue": "[resourceGroup().location]"
+              },
+              "bastionName": {
+                "type": "string"
+              },
+              "vNetName": {
+                "type": "string"
+              },
+              "bastionSubnetName": {
+                "type": "string"
+              },
+              "logAnalyticsWorkspaceId": {
+                "type": "string",
+                "defaultValue": ""
+              }
+            },
+            "functions": [],
+            "variables": {
+              "bastionHostName": "[format('bas-{0}', parameters('bastionName'))]",
+              "bastionIpAddressName": "[format('pip-{0}', parameters('bastionName'))]"
+            },
+            "resources": [
+              {
+                "type": "Microsoft.Network/publicIPAddresses",
+                "apiVersion": "2022-07-01",
+                "name": "[variables('bastionIpAddressName')]",
+                "location": "[parameters('location')]",
+                "sku": {
+                  "name": "Standard"
+                },
+                "properties": {
+                  "publicIPAddressVersion": "IPv4",
+                  "publicIPAllocationMethod": "Static",
+                  "idleTimeoutInMinutes": 4
+                }
+              },
+              {
+                "type": "Microsoft.Network/bastionHosts",
+                "apiVersion": "2022-07-01",
+                "name": "[variables('bastionHostName')]",
+                "location": "[parameters('location')]",
+                "sku": {
+                  "name": "Basic"
+                },
+                "properties": {
+                  "ipConfigurations": [
+                    {
+                      "name": "ipconfig01",
+                      "properties": {
+                        "privateIPAllocationMethod": "Dynamic",
+                        "publicIPAddress": {
+                          "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('bastionIpAddressName'))]"
+                        },
+                        "subnet": {
+                          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vNetName'), parameters('bastionSubnetName'))]"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "dependsOn": [
+                  "[resourceId('Microsoft.Network/publicIPAddresses', variables('bastionIpAddressName'))]"
+                ]
+              },
+              {
+                "condition": "[not(empty(parameters('logAnalyticsWorkspaceId')))]",
+                "type": "Microsoft.Insights/diagnosticSettings",
+                "apiVersion": "2021-05-01-preview",
+                "scope": "[format('Microsoft.Network/bastionHosts/{0}', variables('bastionHostName'))]",
+                "name": "[format('{0}-diagnosticsettings', variables('bastionHostName'))]",
+                "properties": {
+                  "logs": [
+                    {
+                      "categoryGroup": "allLogs",
+                      "enabled": true
+                    }
+                  ],
+                  "metrics": [
+                    {
+                      "category": "AllMetrics",
+                      "enabled": true
+                    }
+                  ],
+                  "workspaceId": "[parameters('logAnalyticsWorkspaceId')]"
+                },
+                "dependsOn": [
+                  "[resourceId('Microsoft.Network/bastionHosts', variables('bastionHostName'))]"
+                ]
+              },
+              {
+                "condition": "[not(empty(parameters('logAnalyticsWorkspaceId')))]",
+                "type": "Microsoft.Insights/diagnosticSettings",
+                "apiVersion": "2021-05-01-preview",
+                "scope": "[format('Microsoft.Network/publicIPAddresses/{0}', variables('bastionIpAddressName'))]",
+                "name": "[format('{0}-diagnosticsettings', variables('bastionIpAddressName'))]",
+                "properties": {
+                  "logs": [
+                    {
+                      "categoryGroup": "allLogs",
+                      "enabled": true
+                    }
+                  ],
+                  "metrics": [
+                    {
+                      "category": "AllMetrics",
+                      "enabled": true
+                    }
+                  ],
+                  "workspaceId": "[parameters('logAnalyticsWorkspaceId')]"
+                },
+                "dependsOn": [
+                  "[resourceId('Microsoft.Network/publicIPAddresses', variables('bastionIpAddressName'))]"
+                ]
+              }
+            ]
+          }
+        },
+        "dependsOn": [
+          "[resourceId('Microsoft.Resources/deployments', 'vnet')]"
+        ]
+      },
+      {
+        "type": "Microsoft.Resources/deployments",
+        "apiVersion": "2019-10-01",
+        "name": "[format('virtual-machine-{0}', parameters('vmName'))]",
+        "properties": {
+          "expressionEvaluationOptions": {
+            "scope": "inner"
+          },
+          "mode": "Incremental",
+          "parameters": {
+            "location": {
+              "value": "[parameters('location')]"
+            },
+            "vmName": {
+              "value": "[parameters('vmName')]"
+            },
+            "adminUsername": {
+              "value": "[parameters('adminUsername')]"
+            },
+            "sshPublicKey": {
+              "value": "[parameters('sshPublicKey')]"
+            },
+            "vmSize": {
+              "value": "[parameters('vmSize')]"
+            },
+            "osdiskSizeGB": {
+              "value": "[parameters('osdiskSizeGB')]"
+            },
+            "ubuntuOffer": {
+              "value": "[parameters('ubuntuOffer')]"
+            },
+            "ubuntuSku": {
+              "value": "[parameters('ubuntuSku')]"
+            },
+            "vNetName": {
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2019-10-01').outputs.vNetName.value]"
+            },
+            "vmSubnetName": {
+              "value": "[parameters('vmSubnetName')]"
+            }
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "location": {
+                "type": "string",
+                "defaultValue": "[resourceGroup().location]"
+              },
+              "vNetName": {
+                "type": "string"
+              },
+              "vmSubnetName": {
+                "type": "string"
+              },
+              "vmName": {
+                "type": "string"
+              },
+              "vmSize": {
+                "type": "string"
+              },
+              "osdiskSizeGB": {
+                "type": "int"
+              },
+              "ubuntuOffer": {
+                "type": "string"
+              },
+              "ubuntuSku": {
+                "type": "string"
+              },
+              "adminUsername": {
+                "type": "string"
+              },
+              "sshPublicKey": {
+                "type": "secureString"
+              }
+            },
+            "functions": [],
+            "resources": [
+              {
+                "type": "Microsoft.Network/networkInterfaces",
+                "apiVersion": "2022-07-01",
+                "name": "[format('{0}-nic', parameters('vmName'))]",
+                "location": "[parameters('location')]",
+                "properties": {
+                  "ipConfigurations": [
+                    {
+                      "name": "ipconfig1",
+                      "properties": {
+                        "primary": true,
+                        "privateIPAllocationMethod": "Dynamic",
+                        "subnet": {
+                          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vNetName'), parameters('vmSubnetName'))]"
+                        }
+                      }
+                    }
+                  ],
+                  "enableIPForwarding": false
+                }
+              },
+              {
+                "type": "Microsoft.Compute/virtualMachines",
+                "apiVersion": "2022-08-01",
+                "name": "[parameters('vmName')]",
+                "location": "[parameters('location')]",
+                "properties": {
+                  "hardwareProfile": {
+                    "vmSize": "[parameters('vmSize')]"
+                  },
+                  "osProfile": {
+                    "computerName": "[parameters('vmName')]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "linuxConfiguration": {
+                      "disablePasswordAuthentication": true,
+                      "ssh": {
+                        "publicKeys": [
+                          {
+                            "path": "[format('/home/{0}/.ssh/authorized_keys', parameters('adminUsername'))]",
+                            "keyData": "[parameters('sshPublicKey')]"
+                          }
+                        ]
+                      },
+                      "patchSettings": {
+                        "patchMode": "AutomaticByPlatform"
+                      }
+                    }
+                  },
+                  "storageProfile": {
+                    "imageReference": {
+                      "publisher": "Canonical",
+                      "offer": "[parameters('ubuntuOffer')]",
+                      "sku": "[parameters('ubuntuSku')]",
+                      "version": "latest"
+                    },
+                    "osDisk": {
+                      "name": "[format('{0}-osdisk', parameters('vmName'))]",
+                      "managedDisk": {
+                        "storageAccountType": "Premium_LRS"
+                      },
+                      "caching": "ReadWrite",
+                      "createOption": "FromImage",
+                      "diskSizeGB": "[parameters('osdiskSizeGB')]"
+                    }
+                  },
+                  "networkProfile": {
+                    "networkInterfaces": [
+                      {
+                        "id": "[resourceId('Microsoft.Network/networkInterfaces', format('{0}-nic', parameters('vmName')))]"
+                      }
+                    ]
+                  }
+                },
+                "dependsOn": [
+                  "[resourceId('Microsoft.Network/networkInterfaces', format('{0}-nic', parameters('vmName')))]"
+                ]
+              }
+            ]
+          }
+        },
+        "dependsOn": [
+          "[resourceId('Microsoft.Resources/deployments', 'vnet')]"
+        ]
+      }
+    ],
+    "metadata": {
+      "_generator": {
+        "name": "bicep",
+        "version": "0.3.126.58533",
+        "templateHash": "5359453205113436776"
+      }
+    }
+  }

--- a/workloads/vm-starter-kit-linux/vm-starter-kit-linux.bicep
+++ b/workloads/vm-starter-kit-linux/vm-starter-kit-linux.bicep
@@ -1,0 +1,132 @@
+param vmName string
+param vmSize string = 'Standard_B1s'
+param adminUsername string
+param adminPassword securestring
+
+var location = resourceGroup().location
+var publisher = 'Canonical'
+var offer = 'UbuntuServer'
+var sku = '16.04-LTS'
+var vmReference = 'Microsoft.Compute/virtualMachines/${vmName}'
+var nicName = '${vmName}-nic'
+var publicIPAddressName = '${vmName}-ip'
+var publicIPAddressType = 'Dynamic'
+var publicIPAddressSku = 'Basic'
+var vnetName = '${vmName}-vnet'
+var vnetAddressPrefix = '10.0.0.0/16'
+var subnetName = '${vmName}-subnet'
+var subnetAddressPrefix = '10.0.0.0/24'
+var storageAccountName = uniqueString(resourceGroup().id) + 'sa'
+var storageAccountType = 'Standard_LRS'
+var osDiskName = '${vmName}-osdisk'
+var osDiskVhdUri = 'https://' + storageAccountName + '.blob.core.windows.net/vhds/${vmName}-osdisk.vhd'
+var imageReference = {
+    publisher: publisher
+    offer: offer
+    sku: sku
+    version: 'latest'
+}
+var nicId = resourceId('Microsoft.Network/networkInterfaces', nicName)
+var publicIPAddressId = resourceId('Microsoft.Network/publicIPAddresses', publicIPAddressName)
+var vnetId = resourceId('Microsoft.Network/virtualNetworks', vnetName)
+var subnetRef = '${vnetId}/subnets/${subnetName}'
+
+resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2021-02-01' = {
+    name: publicIPAddressName
+    location: location
+    sku: {
+        name: publicIPAddressSku
+    }
+    properties: {
+        publicIPAllocationMethod: publicIPAddressType
+    }
+}
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-02-01' = {
+    name: vnetName
+    location: location
+    properties: {
+        addressSpace: {
+            addressPrefixes: [
+                vnetAddressPrefix
+            ]
+        }
+        subnets: [
+            {
+                name: subnetName
+                properties: {
+                    addressPrefix: subnetAddressPrefix
+                }
+            }
+        ]
+    }
+}
+
+resource networkInterface 'Microsoft.Network/networkInterfaces@2021-02-01' = {
+    name: nicName
+    location: location
+    dependsOn: [
+        publicIPAddress
+        virtualNetwork
+    ]
+    properties: {
+        ipConfigurations: [
+            {
+                name: 'ipconfig1'
+                properties: {
+                    privateIPAllocationMethod: 'Dynamic'
+                    publicIPAddress: {
+                        id: publicIPAddressId
+                    }
+                    subnet: {
+                        id: subnetRef
+                    }
+                }
+            }
+        ]
+    }
+}
+
+resource virtualMachine 'Microsoft.Compute/virtualMachines@2021-03-01' = {
+    name: vmName
+    location: location
+    dependsOn: [
+        networkInterface
+    ]
+    properties: {
+        hardwareProfile: {
+            vmSize: vmSize
+        }
+        storageProfile: {
+            osDisk: {
+                name: osDiskName
+                createOption: 'FromImage'
+                caching: 'ReadWrite'
+                managedDisk: {
+                    storageAccountType: storageAccountType
+                }
+                osType: 'Linux'
+                diskSizeGB: 30
+                vhd: {
+                    uri: osDiskVhdUri
+                }
+            }
+            imageReference: imageReference
+        }
+        osProfile: {
+            computerName: vmName
+            adminUsername: adminUsername
+            adminPassword: adminPassword
+            linuxConfiguration: {
+                disablePasswordAuthentication: false
+            }
+        }
+        networkProfile: {
+            networkInterfaces: [
+                {
+                    id: nicId
+                }
+            ]
+        }
+    }
+}

--- a/workloads/vm-starter-kit-linux/vm-starter-kit-linux.ps1
+++ b/workloads/vm-starter-kit-linux/vm-starter-kit-linux.ps1
@@ -1,0 +1,35 @@
+# Define variables
+$resourceGroupName = "myResourceGroup"
+$location = "eastus"
+$vmName = "myVM"
+$vmSize = "Standard_DS2_v2"
+$adminUsername = "adminUser"
+$adminPassword = "adminPassword"
+
+# Create a new resource group
+New-AzResourceGroup -Name $resourceGroupName -Location $location
+
+# Create a new virtual network
+$vnet = New-AzVirtualNetwork -ResourceGroupName $resourceGroupName -Location $location -Name "myVNet" -AddressPrefix "10.0.0.0/16"
+
+# Create a new subnet
+$subnet = Add-AzVirtualNetworkSubnetConfig -Name "mySubnet" -AddressPrefix "10.0.0.0/24" -VirtualNetwork $vnet
+
+# Create a new public IP address
+$publicIP = New-AzPublicIpAddress -ResourceGroupName $resourceGroupName -Location $location -Name "myPublicIP" -AllocationMethod Dynamic
+
+# Create a new network security group
+$nsg = New-AzNetworkSecurityGroup -ResourceGroupName $resourceGroupName -Location $location -Name "myNSG"
+
+# Create a new virtual network interface
+$nic = New-AzNetworkInterface -ResourceGroupName $resourceGroupName -Location $location -Name "myNIC" -SubnetId $vnet.Subnets[0].Id -PublicIpAddressId $publicIP.Id -NetworkSecurityGroupId $nsg.Id
+
+# Create a new virtual machine
+$vmConfig = New-AzVMConfig -VMName $vmName -VMSize $vmSize
+$vmConfig = Set-AzVMOperatingSystem -VM $vmConfig -Linux -ComputerName $vmName -Credential (Get-Credential -UserName $adminUsername -Password $adminPassword)
+$vmConfig = Add-AzVMNetworkInterface -VM $vmConfig -Id $nic.Id
+$vmConfig = Set-AzVMSourceImage -VM $vmConfig -PublisherName "Canonical" -Offer "UbuntuServer" -Skus "18.04-LTS" -Version "latest"
+$vm = New-AzVM -ResourceGroupName $resourceGroupName -Location $location -VM $vmConfig
+
+# Output the public IP address of the VM
+$vm.PublicIpAddress

--- a/workloads/vm-starter-kit-linux/vm-starter-kit-linux.tf
+++ b/workloads/vm-starter-kit-linux/vm-starter-kit-linux.tf
@@ -1,0 +1,104 @@
+provider "azurerm" {
+    features {}
+}
+
+resource "azurerm_resource_group" "example" {
+    name     = "example-resources"
+    location = "eastus"
+}
+
+resource "azurerm_virtual_network" "example" {
+    name                = "example-network"
+    address_space       = ["10.0.0.0/16"]
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_subnet" "example" {
+    name                 = "example-subnet"
+    resource_group_name  = azurerm_resource_group.example.name
+    virtual_network_name = azurerm_virtual_network.example.name
+    address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_public_ip" "example" {
+    name                = "example-public-ip"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+    allocation_method   = "Dynamic"
+}
+
+resource "azurerm_network_security_group" "example" {
+    name                = "example-nsg"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+
+    security_rule {
+        name                       = "HTTP"
+        priority                   = 1001
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "80"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+    }
+
+    security_rule {
+        name                       = "SSH"
+        priority                   = 1002
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "22"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+    }
+}
+
+resource "azurerm_network_interface" "example" {
+    name                = "example-nic"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+
+    ip_configuration {
+        name                          = "internal"
+        subnet_id                     = azurerm_subnet.example.id
+        private_ip_address_allocation = "Dynamic"
+        public_ip_address_id          = azurerm_public_ip.example.id
+    }
+}
+
+resource "azurerm_linux_virtual_machine" "example" {
+    name                = "example-vm"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+
+    size                 = "Standard_B1s"
+    admin_username       = "adminuser"
+    network_interface_ids = [azurerm_network_interface.example.id]
+
+    source_image_reference {
+        publisher = "Canonical"
+        offer     = "UbuntuServer"
+        sku       = "18.04-LTS"
+        version   = "latest"
+    }
+
+    os_disk {
+        name              = "example-os-disk"
+        caching           = "ReadWrite"
+        storage_account_type = "Standard_LRS"
+    }
+
+    computer_name  = "examplevm"
+    admin_password = "Password1234!"
+
+    custom_data = <<-EOF
+                                #!/bin/bash
+                                sudo apt-get update
+                                sudo apt-get install -y apache2 mysql-server php libapache2-mod-php php-mysql
+                                EOF
+}

--- a/workloads/vm-starter-kit-windows/vm-starter-kit-windows.arm/parameters.json
+++ b/workloads/vm-starter-kit-windows/vm-starter-kit-windows.arm/parameters.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "resourceNamePrefix": {
+            "value": "linux-vm-"
+        },
+        "sshPublicKey": {
+            "value": ""
+        },
+        "location": {
+            "value": "eastus"
+        },
+        "vmSize": {
+            "value": "Standard_DS2_v2"
+        },
+        "adminUsername": {
+            "value": "adminuser"
+        },
+        "adminPassword": {
+            "value": "password123"
+        }
+    }
+}

--- a/workloads/vm-starter-kit-windows/vm-starter-kit-windows.arm/template.json
+++ b/workloads/vm-starter-kit-windows/vm-starter-kit-windows.arm/template.json
@@ -1,0 +1,508 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "location": {
+        "type": "string",
+        "defaultValue": "[resourceGroup().location]"
+      },
+      "bastionName": {
+        "type": "string",
+        "defaultValue": "BastionHost"
+      },
+      "networkName": {
+        "type": "string",
+        "defaultValue": "VmStarterKit"
+      },
+      "vmSubnetName": {
+        "type": "string",
+        "defaultValue": "VMs"
+      },
+      "vmName": {
+        "type": "string",
+        "defaultValue": "vm-01"
+      },
+      "vmSize": {
+        "type": "string",
+        "defaultValue": "Standard_D2s_v5"
+      },
+      "windowsOffer": {
+        "type": "string",
+        "defaultValue": "WindowsServer"
+      },
+      "windowsSku": {
+        "type": "string",
+        "defaultValue": "2022-datacenter-azure-edition-core"
+      },
+      "adminUsername": {
+        "type": "string"
+      },
+      "adminPassword": {
+        "type": "secureString"
+      }
+    },
+    "functions": [],
+    "resources": [
+      {
+        "type": "Microsoft.Resources/deployments",
+        "apiVersion": "2019-10-01",
+        "name": "vnet",
+        "properties": {
+          "expressionEvaluationOptions": {
+            "scope": "inner"
+          },
+          "mode": "Incremental",
+          "parameters": {
+            "location": {
+              "value": "[parameters('location')]"
+            },
+            "networkName": {
+              "value": "[parameters('networkName')]"
+            },
+            "vmSubnetName": {
+              "value": "[parameters('vmSubnetName')]"
+            }
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "location": {
+                "type": "string",
+                "defaultValue": "[resourceGroup().location]"
+              },
+              "networkName": {
+                "type": "string"
+              },
+              "vmSubnetName": {
+                "type": "string"
+              },
+              "openWebPorts": {
+                "type": "bool",
+                "defaultValue": false
+              },
+              "logAnalyticsWorkspaceId": {
+                "type": "string",
+                "defaultValue": ""
+              }
+            },
+            "functions": [],
+            "variables": {
+              "vNetName": "[format('vnet-{0}', parameters('networkName'))]",
+              "vNetAddressPrefix": "10.1.0.0/16",
+              "bastionSubnetAddressPrefix": "10.1.0.0/24",
+              "vmSubnetAddressPrefix": "10.1.1.0/24",
+              "nsgName": "[format('nsg-subnet-{0}', parameters('vmSubnetName'))]",
+              "bastionSubnetName": "AzureBastionSubnet"
+            },
+            "resources": [
+              {
+                "type": "Microsoft.Network/networkSecurityGroups",
+                "apiVersion": "2022-07-01",
+                "name": "[variables('nsgName')]",
+                "location": "[parameters('location')]",
+                "properties": {
+                  "securityRules": "[if(equals(parameters('openWebPorts'), false()), createArray(), createArray(createObject('name', 'AllowHttpInbound', 'properties', createObject('protocol', 'Tcp', 'sourcePortRange', '*', 'destinationPortRange', '80', 'sourceAddressPrefix', 'Internet', 'destinationAddressPrefix', '*', 'access', 'Allow', 'priority', 100, 'direction', 'Inbound'))))]"
+                }
+              },
+              {
+                "type": "Microsoft.Network/virtualNetworks",
+                "apiVersion": "2022-07-01",
+                "name": "[variables('vNetName')]",
+                "location": "[parameters('location')]",
+                "properties": {
+                  "addressSpace": {
+                    "addressPrefixes": [
+                      "[variables('vNetAddressPrefix')]"
+                    ]
+                  },
+                  "subnets": [
+                    {
+                      "name": "[variables('bastionSubnetName')]",
+                      "properties": {
+                        "addressPrefix": "[variables('bastionSubnetAddressPrefix')]",
+                        "privateEndpointNetworkPolicies": "Disabled"
+                      }
+                    },
+                    {
+                      "name": "[parameters('vmSubnetName')]",
+                      "properties": {
+                        "addressPrefix": "[variables('vmSubnetAddressPrefix')]",
+                        "privateEndpointNetworkPolicies": "Disabled",
+                        "networkSecurityGroup": {
+                          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgName'))]"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "dependsOn": [
+                  "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgName'))]"
+                ]
+              },
+              {
+                "condition": "[not(empty(parameters('logAnalyticsWorkspaceId')))]",
+                "type": "Microsoft.Insights/diagnosticSettings",
+                "apiVersion": "2021-05-01-preview",
+                "scope": "[format('Microsoft.Network/virtualNetworks/{0}', variables('vNetName'))]",
+                "name": "[format('{0}-diagnosticsettings', variables('vNetName'))]",
+                "properties": {
+                  "logs": [
+                    {
+                      "categoryGroup": "allLogs",
+                      "enabled": true
+                    }
+                  ],
+                  "metrics": [
+                    {
+                      "category": "AllMetrics",
+                      "enabled": true
+                    }
+                  ],
+                  "workspaceId": "[parameters('logAnalyticsWorkspaceId')]"
+                },
+                "dependsOn": [
+                  "[resourceId('Microsoft.Network/virtualNetworks', variables('vNetName'))]"
+                ]
+              },
+              {
+                "condition": "[not(empty(parameters('logAnalyticsWorkspaceId')))]",
+                "type": "Microsoft.Insights/diagnosticSettings",
+                "apiVersion": "2021-05-01-preview",
+                "scope": "[format('Microsoft.Network/networkSecurityGroups/{0}', variables('nsgName'))]",
+                "name": "[format('{0}-diagnosticsettings', variables('nsgName'))]",
+                "properties": {
+                  "logs": [
+                    {
+                      "categoryGroup": "allLogs",
+                      "enabled": true
+                    }
+                  ],
+                  "workspaceId": "[parameters('logAnalyticsWorkspaceId')]"
+                },
+                "dependsOn": [
+                  "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgName'))]"
+                ]
+              }
+            ],
+            "outputs": {
+              "vNetName": {
+                "type": "string",
+                "value": "[variables('vNetName')]"
+              },
+              "bastionSubnetName": {
+                "type": "string",
+                "value": "[variables('bastionSubnetName')]"
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "Microsoft.Resources/deployments",
+        "apiVersion": "2019-10-01",
+        "name": "bastion",
+        "properties": {
+          "expressionEvaluationOptions": {
+            "scope": "inner"
+          },
+          "mode": "Incremental",
+          "parameters": {
+            "location": {
+              "value": "[parameters('location')]"
+            },
+            "bastionName": {
+              "value": "[parameters('bastionName')]"
+            },
+            "vNetName": {
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2019-10-01').outputs.vNetName.value]"
+            },
+            "bastionSubnetName": {
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2019-10-01').outputs.bastionSubnetName.value]"
+            }
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "location": {
+                "type": "string",
+                "defaultValue": "[resourceGroup().location]"
+              },
+              "bastionName": {
+                "type": "string"
+              },
+              "vNetName": {
+                "type": "string"
+              },
+              "bastionSubnetName": {
+                "type": "string"
+              },
+              "logAnalyticsWorkspaceId": {
+                "type": "string",
+                "defaultValue": ""
+              }
+            },
+            "functions": [],
+            "variables": {
+              "bastionHostName": "[format('bas-{0}', parameters('bastionName'))]",
+              "bastionIpAddressName": "[format('pip-{0}', parameters('bastionName'))]"
+            },
+            "resources": [
+              {
+                "type": "Microsoft.Network/publicIPAddresses",
+                "apiVersion": "2022-07-01",
+                "name": "[variables('bastionIpAddressName')]",
+                "location": "[parameters('location')]",
+                "sku": {
+                  "name": "Standard"
+                },
+                "properties": {
+                  "publicIPAddressVersion": "IPv4",
+                  "publicIPAllocationMethod": "Static",
+                  "idleTimeoutInMinutes": 4
+                }
+              },
+              {
+                "type": "Microsoft.Network/bastionHosts",
+                "apiVersion": "2022-07-01",
+                "name": "[variables('bastionHostName')]",
+                "location": "[parameters('location')]",
+                "sku": {
+                  "name": "Basic"
+                },
+                "properties": {
+                  "ipConfigurations": [
+                    {
+                      "name": "ipconfig01",
+                      "properties": {
+                        "privateIPAllocationMethod": "Dynamic",
+                        "publicIPAddress": {
+                          "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('bastionIpAddressName'))]"
+                        },
+                        "subnet": {
+                          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vNetName'), parameters('bastionSubnetName'))]"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "dependsOn": [
+                  "[resourceId('Microsoft.Network/publicIPAddresses', variables('bastionIpAddressName'))]"
+                ]
+              },
+              {
+                "condition": "[not(empty(parameters('logAnalyticsWorkspaceId')))]",
+                "type": "Microsoft.Insights/diagnosticSettings",
+                "apiVersion": "2021-05-01-preview",
+                "scope": "[format('Microsoft.Network/bastionHosts/{0}', variables('bastionHostName'))]",
+                "name": "[format('{0}-diagnosticsettings', variables('bastionHostName'))]",
+                "properties": {
+                  "logs": [
+                    {
+                      "categoryGroup": "allLogs",
+                      "enabled": true
+                    }
+                  ],
+                  "metrics": [
+                    {
+                      "category": "AllMetrics",
+                      "enabled": true
+                    }
+                  ],
+                  "workspaceId": "[parameters('logAnalyticsWorkspaceId')]"
+                },
+                "dependsOn": [
+                  "[resourceId('Microsoft.Network/bastionHosts', variables('bastionHostName'))]"
+                ]
+              },
+              {
+                "condition": "[not(empty(parameters('logAnalyticsWorkspaceId')))]",
+                "type": "Microsoft.Insights/diagnosticSettings",
+                "apiVersion": "2021-05-01-preview",
+                "scope": "[format('Microsoft.Network/publicIPAddresses/{0}', variables('bastionIpAddressName'))]",
+                "name": "[format('{0}-diagnosticsettings', variables('bastionIpAddressName'))]",
+                "properties": {
+                  "logs": [
+                    {
+                      "categoryGroup": "allLogs",
+                      "enabled": true
+                    }
+                  ],
+                  "metrics": [
+                    {
+                      "category": "AllMetrics",
+                      "enabled": true
+                    }
+                  ],
+                  "workspaceId": "[parameters('logAnalyticsWorkspaceId')]"
+                },
+                "dependsOn": [
+                  "[resourceId('Microsoft.Network/publicIPAddresses', variables('bastionIpAddressName'))]"
+                ]
+              }
+            ]
+          }
+        },
+        "dependsOn": [
+          "[resourceId('Microsoft.Resources/deployments', 'vnet')]"
+        ]
+      },
+      {
+        "type": "Microsoft.Resources/deployments",
+        "apiVersion": "2019-10-01",
+        "name": "[format('virtual-machine-{0}', parameters('vmName'))]",
+        "properties": {
+          "expressionEvaluationOptions": {
+            "scope": "inner"
+          },
+          "mode": "Incremental",
+          "parameters": {
+            "location": {
+              "value": "[parameters('location')]"
+            },
+            "vmName": {
+              "value": "[parameters('vmName')]"
+            },
+            "adminUsername": {
+              "value": "[parameters('adminUsername')]"
+            },
+            "adminPassword": {
+              "value": "[parameters('adminPassword')]"
+            },
+            "vmSize": {
+              "value": "[parameters('vmSize')]"
+            },
+            "windowsOffer": {
+              "value": "[parameters('windowsOffer')]"
+            },
+            "windowsSku": {
+              "value": "[parameters('windowsSku')]"
+            },
+            "vNetName": {
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2019-10-01').outputs.vNetName.value]"
+            },
+            "vmSubnetName": {
+              "value": "[parameters('vmSubnetName')]"
+            }
+          },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "location": {
+                "type": "string",
+                "defaultValue": "[resourceGroup().location]"
+              },
+              "vNetName": {
+                "type": "string"
+              },
+              "vmSubnetName": {
+                "type": "string"
+              },
+              "vmName": {
+                "type": "string"
+              },
+              "vmSize": {
+                "type": "string"
+              },
+              "windowsOffer": {
+                "type": "string"
+              },
+              "windowsSku": {
+                "type": "string"
+              },
+              "adminUsername": {
+                "type": "string"
+              },
+              "adminPassword": {
+                "type": "secureString"
+              }
+            },
+            "functions": [],
+            "resources": [
+              {
+                "type": "Microsoft.Network/networkInterfaces",
+                "apiVersion": "2022-07-01",
+                "name": "[format('{0}-nic', parameters('vmName'))]",
+                "location": "[parameters('location')]",
+                "properties": {
+                  "ipConfigurations": [
+                    {
+                      "name": "ipconfig1",
+                      "properties": {
+                        "primary": true,
+                        "privateIPAllocationMethod": "Dynamic",
+                        "subnet": {
+                          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vNetName'), parameters('vmSubnetName'))]"
+                        }
+                      }
+                    }
+                  ],
+                  "enableIPForwarding": false
+                }
+              },
+              {
+                "type": "Microsoft.Compute/virtualMachines",
+                "apiVersion": "2022-08-01",
+                "name": "[parameters('vmName')]",
+                "location": "[parameters('location')]",
+                "properties": {
+                  "hardwareProfile": {
+                    "vmSize": "[parameters('vmSize')]"
+                  },
+                  "osProfile": {
+                    "computerName": "[parameters('vmName')]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPassword')]",
+                    "windowsConfiguration": {
+                      "patchSettings": {
+                        "patchMode": "AutomaticByPlatform",
+                        "enableHotpatching": true
+                      }
+                    }
+                  },
+                  "storageProfile": {
+                    "imageReference": {
+                      "publisher": "MicrosoftWindowsServer",
+                      "offer": "[parameters('windowsOffer')]",
+                      "sku": "[parameters('windowsSku')]",
+                      "version": "latest"
+                    },
+                    "osDisk": {
+                      "name": "[format('{0}-osdisk', parameters('vmName'))]",
+                      "managedDisk": {
+                        "storageAccountType": "Premium_LRS"
+                      },
+                      "caching": "ReadWrite",
+                      "createOption": "FromImage"
+                    }
+                  },
+                  "networkProfile": {
+                    "networkInterfaces": [
+                      {
+                        "id": "[resourceId('Microsoft.Network/networkInterfaces', format('{0}-nic', parameters('vmName')))]"
+                      }
+                    ]
+                  }
+                },
+                "dependsOn": [
+                  "[resourceId('Microsoft.Network/networkInterfaces', format('{0}-nic', parameters('vmName')))]"
+                ]
+              }
+            ]
+          }
+        },
+        "dependsOn": [
+          "[resourceId('Microsoft.Resources/deployments', 'vnet')]"
+        ]
+      }
+    ],
+    "metadata": {
+      "_generator": {
+        "name": "bicep",
+        "version": "0.3.126.58533",
+        "templateHash": "12897471974930090393"
+      }
+    }
+}

--- a/workloads/vm-starter-kit-windows/vm-starter-kit-windows.bicep
+++ b/workloads/vm-starter-kit-windows/vm-starter-kit-windows.bicep
@@ -1,0 +1,132 @@
+param vmName string
+param vmSize string = 'Standard_B1s'
+param adminUsername string
+param adminPassword securestring
+
+var location = resourceGroup().location
+var publisher = 'Canonical'
+var offer = 'UbuntuServer'
+var sku = '16.04-LTS'
+var vmReference = 'Microsoft.Compute/virtualMachines/${vmName}'
+var nicName = '${vmName}-nic'
+var publicIPAddressName = '${vmName}-ip'
+var publicIPAddressType = 'Dynamic'
+var publicIPAddressSku = 'Basic'
+var vnetName = '${vmName}-vnet'
+var vnetAddressPrefix = '10.0.0.0/16'
+var subnetName = '${vmName}-subnet'
+var subnetAddressPrefix = '10.0.0.0/24'
+var storageAccountName = uniqueString(resourceGroup().id) + 'sa'
+var storageAccountType = 'Standard_LRS'
+var osDiskName = '${vmName}-osdisk'
+var osDiskVhdUri = 'https://' + storageAccountName + '.blob.core.windows.net/vhds/${vmName}-osdisk.vhd'
+var imageReference = {
+    publisher: publisher
+    offer: offer
+    sku: sku
+    version: 'latest'
+}
+var nicId = resourceId('Microsoft.Network/networkInterfaces', nicName)
+var publicIPAddressId = resourceId('Microsoft.Network/publicIPAddresses', publicIPAddressName)
+var vnetId = resourceId('Microsoft.Network/virtualNetworks', vnetName)
+var subnetRef = '${vnetId}/subnets/${subnetName}'
+
+resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2021-02-01' = {
+    name: publicIPAddressName
+    location: location
+    sku: {
+        name: publicIPAddressSku
+    }
+    properties: {
+        publicIPAllocationMethod: publicIPAddressType
+    }
+}
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-02-01' = {
+    name: vnetName
+    location: location
+    properties: {
+        addressSpace: {
+            addressPrefixes: [
+                vnetAddressPrefix
+            ]
+        }
+        subnets: [
+            {
+                name: subnetName
+                properties: {
+                    addressPrefix: subnetAddressPrefix
+                }
+            }
+        ]
+    }
+}
+
+resource networkInterface 'Microsoft.Network/networkInterfaces@2021-02-01' = {
+    name: nicName
+    location: location
+    dependsOn: [
+        publicIPAddress
+        virtualNetwork
+    ]
+    properties: {
+        ipConfigurations: [
+            {
+                name: 'ipconfig1'
+                properties: {
+                    privateIPAllocationMethod: 'Dynamic'
+                    publicIPAddress: {
+                        id: publicIPAddressId
+                    }
+                    subnet: {
+                        id: subnetRef
+                    }
+                }
+            }
+        ]
+    }
+}
+
+resource virtualMachine 'Microsoft.Compute/virtualMachines@2021-03-01' = {
+    name: vmName
+    location: location
+    dependsOn: [
+        networkInterface
+    ]
+    properties: {
+        hardwareProfile: {
+            vmSize: vmSize
+        }
+        storageProfile: {
+            osDisk: {
+                name: osDiskName
+                createOption: 'FromImage'
+                caching: 'ReadWrite'
+                managedDisk: {
+                    storageAccountType: storageAccountType
+                }
+                osType: 'Linux'
+                diskSizeGB: 30
+                vhd: {
+                    uri: osDiskVhdUri
+                }
+            }
+            imageReference: imageReference
+        }
+        osProfile: {
+            computerName: vmName
+            adminUsername: adminUsername
+            adminPassword: adminPassword
+            linuxConfiguration: {
+                disablePasswordAuthentication: false
+            }
+        }
+        networkProfile: {
+            networkInterfaces: [
+                {
+                    id: nicId
+                }
+            ]
+        }
+    }
+}

--- a/workloads/vm-starter-kit-windows/vm-starter-kit-windows.ps1
+++ b/workloads/vm-starter-kit-windows/vm-starter-kit-windows.ps1
@@ -1,0 +1,35 @@
+# Define variables
+$resourceGroupName = "myResourceGroup"
+$location = "eastus"
+$vmName = "myVM"
+$vmSize = "Standard_DS2_v2"
+$adminUsername = "adminUser"
+$adminPassword = "adminPassword"
+
+# Create a new resource group
+New-AzResourceGroup -Name $resourceGroupName -Location $location
+
+# Create a new virtual network
+$vnet = New-AzVirtualNetwork -ResourceGroupName $resourceGroupName -Location $location -Name "myVNet" -AddressPrefix "10.0.0.0/16"
+
+# Create a new subnet
+$subnet = Add-AzVirtualNetworkSubnetConfig -Name "mySubnet" -AddressPrefix "10.0.0.0/24" -VirtualNetwork $vnet
+
+# Create a new public IP address
+$publicIP = New-AzPublicIpAddress -ResourceGroupName $resourceGroupName -Location $location -Name "myPublicIP" -AllocationMethod Dynamic
+
+# Create a new network security group
+$nsg = New-AzNetworkSecurityGroup -ResourceGroupName $resourceGroupName -Location $location -Name "myNSG"
+
+# Create a new virtual network interface
+$nic = New-AzNetworkInterface -ResourceGroupName $resourceGroupName -Location $location -Name "myNIC" -SubnetId $vnet.Subnets[0].Id -PublicIpAddressId $publicIP.Id -NetworkSecurityGroupId $nsg.Id
+
+# Create a new virtual machine
+$vmConfig = New-AzVMConfig -VMName $vmName -VMSize $vmSize
+$vmConfig = Set-AzVMOperatingSystem -VM $vmConfig -Windows -ComputerName $vmName -Credential (Get-Credential -UserName $adminUsername -Password $adminPassword)
+$vmConfig = Add-AzVMNetworkInterface -VM $vmConfig -Id $nic.Id
+$vmConfig = Set-AzVMSourceImage -VM $vmConfig -PublisherName "MicrosoftWindowsServer" -Offer "WindowsServer" -Skus "2019-Datacenter" -Version "latest"
+$vm = New-AzVM -ResourceGroupName $resourceGroupName -Location $location -VM $vmConfig
+
+# Output the public IP address of the VM
+$vm.PublicIpAddress

--- a/workloads/vm-starter-kit-windows/vm-starter-kit-windows.tf
+++ b/workloads/vm-starter-kit-windows/vm-starter-kit-windows.tf
@@ -1,0 +1,118 @@
+provider "azurerm" {
+    features {}
+}
+
+resource "azurerm_resource_group" "example" {
+    name     = "example-resources"
+    location = "eastus"
+}
+
+resource "azurerm_virtual_network" "example" {
+    name                = "example-network"
+    address_space       = ["10.0.0.0/16"]
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_subnet" "example" {
+    name                 = "example-subnet"
+    resource_group_name  = azurerm_resource_group.example.name
+    virtual_network_name = azurerm_virtual_network.example.name
+    address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_public_ip" "example" {
+    name                = "example-public-ip"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+    allocation_method   = "Dynamic"
+}
+
+resource "azurerm_network_security_group" "example" {
+    name                = "example-nsg"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+
+    security_rule {
+        name                       = "HTTP"
+        priority                   = 1001
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "80"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+    }
+
+    security_rule {
+        name                       = "SSH"
+        priority                   = 1002
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "22"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+    }
+}
+
+resource "azurerm_network_interface" "example" {
+    name                = "example-nic"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+
+    ip_configuration {
+        name                          = "internal"
+        subnet_id                     = azurerm_subnet.example.id
+        private_ip_address_allocation = "Dynamic"
+        public_ip_address_id          = azurerm_public_ip.example.id
+    }
+}
+
+resource "azurerm_windows_virtual_machine" "example" {
+    name                = "example-windows-vm"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+
+    size                 = "Standard_B1s"
+    admin_username       = "adminuser"
+    network_interface_ids = [azurerm_network_interface.example.id]
+
+    source_image_reference {
+        publisher = "MicrosoftWindowsServer"
+        offer     = "WindowsServer"
+        sku       = "2019-Datacenter"
+        version   = "latest"
+    }
+
+    os_disk {
+        name              = "example-windows-os-disk"
+        caching           = "ReadWrite"
+        storage_account_type = "Standard_LRS"
+    }
+
+    computer_name  = "examplewindowsvm"
+    admin_password = "Password1234!"
+
+    custom_data = <<-EOF
+                                <powershell>
+                                # Install IIS
+                                Install-WindowsFeature -name Web-Server -IncludeManagementTools
+
+                                # Install MySQL
+                                Install-WindowsFeature -name MySQL
+
+                                # Install PHP
+                                Install-WindowsFeature -name Web-App-Dev -IncludeManagementTools
+
+                                # Configure IIS
+                                Set-WebConfigurationProperty -Filter /system.webServer/security/authentication/windowsAuthentication -name enabled -value true
+                                Set-WebConfigurationProperty -Filter /system.webServer/security/authentication/anonymousAuthentication -name enabled -value false
+
+                                # Restart IIS
+                                Restart-Service -Name W3SVC
+                                </powershell>
+                                EOF
+}

--- a/workloads/wordpress-vm/wordpress-vm.arm/parameters.json
+++ b/workloads/wordpress-vm/wordpress-vm.arm/parameters.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "resourceNamePrefix": {
+            "value": "linux-vm-"
+        },
+        "sshPublicKey": {
+            "value": ""
+        },
+        "location": {
+            "value": "eastus"
+        },
+        "vmSize": {
+            "value": "Standard_DS2_v2"
+        },
+        "adminUsername": {
+            "value": "adminuser"
+        },
+        "adminPassword": {
+            "value": "password123"
+        }
+    }
+}

--- a/workloads/wordpress-vm/wordpress-vm.arm/template.json
+++ b/workloads/wordpress-vm/wordpress-vm.arm/template.json
@@ -1,0 +1,56 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "sshPublicKey": {
+            "metadata": {
+                "description": "ssh public key"
+            },
+            "type": "securestring"
+        },
+        "resourceNamePrefix": {
+            "metadata": {
+                "description": "resource name prefix"
+            },
+            "type": "string"
+        },
+        "epochTime": {
+            "type": "int",
+            "defaultValue": "[dateTimeToEpoch(dateTimeAdd(utcNow(), 'P0Y'))]"
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-10-01",
+            "name": "[concat('Deployment-SolutionCenter-Wordpress-Minimal', '_', parameters('epochTime'))]",
+            "properties": {
+                "mode": "Incremental",
+                "parameters": {
+                    "_artifactsLocation": { "value": "https://raw.githubusercontent.com/Azure/solution-center/main/solutions/wordpress-azure-vm-v1/" },
+                    "_resourceNamePrefix": { "value": "[parameters('resourceNamePrefix')]" },
+                    "redisDeploySwitch": { "value": false },
+                    "sshPublicKey": { "value": "[parameters('sshPublicKey')]" },
+                    "autoscaleVmSku": { "value": "Standard_DS1_v2" },
+                    "enableAccelNwForOtherVmsSwitch": { "value": false },
+                    "dbServerType": { "value": "mysql" },
+                    "fileServerDiskCount": { "value": 2 },
+                    "fileServerDiskSize": { "value": 32 },
+                    "CMSApplication": { "value": "WordPress" }
+                },
+                "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/Azure/solution-center/main/solutions/wordpress-azure-vm-v1/azuredeploy.json"
+                }
+            }
+        }
+    ],
+    "variables": {
+        "documentation01": "This wrapper template calls the main-template with bare minimum configs and the only required parameter (sshPublicKey).",
+        "documentation02": "To speed up deployment and consume least resources, other parameters are fixed in this tempalte and overriden as follows:",
+        "documentation03": "   - fileServerType: nfs",
+        "documentation04": "   - autoscaleVmSku: Standard_DS1_v2",
+        "documentation05": "   - fileServerDiskCount: 2",
+        "documentation06": "   - dbServerType: mysql",
+        "documentation07": "   - redisDeploySwitch: false"
+    }
+}

--- a/workloads/wordpress-vm/wordpress-vm.bicep
+++ b/workloads/wordpress-vm/wordpress-vm.bicep
@@ -1,0 +1,134 @@
+param vmName string
+param vmSize string = 'Standard_B1s'
+param adminUsername string
+param adminPassword securestring
+
+var location = resourceGroup().location
+var publisher = 'Canonical'
+var offer = 'UbuntuServer'
+var sku = '16.04-LTS'
+var vmReference = 'Microsoft.Compute/virtualMachines/${vmName}'
+var nicName = '${vmName}-nic'
+var publicIPAddressName = '${vmName}-ip'
+var publicIPAddressType = 'Dynamic'
+var publicIPAddressSku = 'Basic'
+var vnetName = '${vmName}-vnet'
+var vnetAddressPrefix = '10.0.0.0/16'
+var subnetName = '${vmName}-subnet'
+var subnetAddressPrefix = '10.0.0.0/24'
+var storageAccountName = uniqueString(resourceGroup().id) + 'sa'
+var storageAccountType = 'Standard_LRS'
+var osDiskName = '${vmName}-osdisk'
+var osDiskVhdUri = 'https://' + storageAccountName + '.blob.core.windows.net/vhds/${vmName}-osdisk.vhd'
+var imageReference = {
+    publisher: publisher
+    offer: offer
+    sku: sku
+    version: 'latest'
+}
+var nicId = resourceId('Microsoft.Network/networkInterfaces', nicName)
+var publicIPAddressId = resourceId('Microsoft.Network/publicIPAddresses', publicIPAddressName)
+var vnetId = resourceId('Microsoft.Network/virtualNetworks', vnetName)
+var subnetRef = '${vnetId}/subnets/${subnetName}'
+
+resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2021-02-01' = {
+    name: publicIPAddressName
+    location: location
+    sku: {
+        name: publicIPAddressSku
+    }
+    properties: {
+        publicIPAllocationMethod: publicIPAddressType
+    }
+}
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-02-01' = {
+    name: vnetName
+    location: location
+    properties: {
+        addressSpace: {
+            addressPrefixes: [
+                vnetAddressPrefix
+            ]
+        }
+        subnets: [
+            {
+                name: subnetName
+                properties: {
+                    addressPrefix: subnetAddressPrefix
+                }
+            }
+        ]
+    }
+}
+
+resource networkInterface 'Microsoft.Network/networkInterfaces@2021-02-01' = {
+    name: nicName
+    location: location
+    dependsOn: [
+        publicIPAddress
+        virtualNetwork
+    ]
+    properties: {
+        ipConfigurations: [
+            {
+                name: 'ipconfig1'
+                properties: {
+                    privateIPAllocationMethod: 'Dynamic'
+                    publicIPAddress: {
+                        id: publicIPAddressId
+                    }
+                    subnet: {
+                        id: subnetRef
+                    }
+                }
+            }
+        ]
+    }
+}
+
+resource virtualMachine 'Microsoft.Compute/virtualMachines@2021-03-01' = {
+    name: vmName
+    location: location
+    dependsOn: [
+        networkInterface
+    ]
+    properties: {
+        hardwareProfile: {
+            vmSize: vmSize
+        }
+        storageProfile: {
+            osDisk: {
+                name: osDiskName
+                createOption: 'FromImage'
+                caching: 'ReadWrite'
+                managedDisk: {
+                    storageAccountType: storageAccountType
+                }
+                osType: 'Linux'
+                diskSizeGB: 30
+                vhd: {
+                    uri: osDiskVhdUri
+                }
+            }
+            imageReference: imageReference
+        }
+        osProfile: {
+            computerName: vmName
+            adminUsername: adminUsername
+            adminPassword: adminPassword
+            linuxConfiguration: {
+                disablePasswordAuthentication: false
+            }
+        }
+        networkProfile: {
+            networkInterfaces: [
+                {
+                    id: nicId
+                }
+            ]
+        }
+    }
+}
+
+

--- a/workloads/wordpress-vm/wordpress-vm.ps1
+++ b/workloads/wordpress-vm/wordpress-vm.ps1
@@ -1,0 +1,51 @@
+# Define variables
+$resourceGroupName = "myResourceGroup"
+$location = "eastus"
+$vmName = "myVM"
+$vmSize = "Standard_DS2_v2"
+$adminUsername = "adminUser"
+$adminPassword = "adminPassword"
+
+# Create a new resource group
+New-AzResourceGroup -Name $resourceGroupName -Location $location
+
+# Create a new virtual network
+$vnet = New-AzVirtualNetwork -ResourceGroupName $resourceGroupName -Location $location -Name "myVNet" -AddressPrefix "10.0.0.0/16"
+
+# Create a new subnet
+$subnet = Add-AzVirtualNetworkSubnetConfig -Name "mySubnet" -AddressPrefix "10.0.0.0/24" -VirtualNetwork $vnet
+
+# Create a new public IP address
+$publicIP = New-AzPublicIpAddress -ResourceGroupName $resourceGroupName -Location $location -Name "myPublicIP" -AllocationMethod Dynamic
+
+# Create a new network security group
+$nsg = New-AzNetworkSecurityGroup -ResourceGroupName $resourceGroupName -Location $location -Name "myNSG"
+
+# Create a new virtual network interface
+$nic = New-AzNetworkInterface -ResourceGroupName $resourceGroupName -Location $location -Name "myNIC" -SubnetId $vnet.Subnets[0].Id -PublicIpAddressId $publicIP.Id -NetworkSecurityGroupId $nsg.Id
+
+# Create a new virtual machine
+$vmConfig = New-AzVMConfig -VMName $vmName -VMSize $vmSize
+$vmConfig = Set-AzVMOperatingSystem -VM $vmConfig -Windows -ComputerName $vmName -Credential (Get-Credential -UserName $adminUsername -Password $adminPassword)
+$vmConfig = Add-AzVMNetworkInterface -VM $vmConfig -Id $nic.Id
+$vmConfig = Set-AzVMSourceImage -VM $vmConfig -PublisherName "MicrosoftWindowsServer" -Offer "WindowsServer" -Skus "2019-Datacenter" -Version "latest"
+$vm = New-AzVM -ResourceGroupName $resourceGroupName -Location $location -VM $vmConfig
+
+# Output the public IP address of the VM
+$vm.PublicIpAddress
+# Install WordPress
+Invoke-Command -ComputerName $vm.PublicIpAddress -ScriptBlock {
+    # Download and install WordPress
+    Invoke-WebRequest -Uri "https://wordpress.org/latest.zip" -OutFile "C:\inetpub\wwwroot\wordpress.zip"
+    Expand-Archive -Path "C:\inetpub\wwwroot\wordpress.zip" -DestinationPath "C:\inetpub\wwwroot"
+    Rename-Item -Path "C:\inetpub\wwwroot\wordpress" -NewName "wordpress"
+
+    # Configure WordPress
+    $wpConfigPath = "C:\inetpub\wwwroot\wordpress\wp-config.php"
+    $wpConfig = Get-Content -Path $wpConfigPath
+    $wpConfig = $wpConfig -replace "database_name_here", "wordpress"
+    $wpConfig = $wpConfig -replace "username_here", "db_user"
+    $wpConfig = $wpConfig -replace "password_here", "db_password"
+    $wpConfig = $wpConfig -replace "localhost", "db_host"
+    $wpConfig | Set-Content -Path $wpConfigPath
+}

--- a/workloads/wordpress-vm/wordpress-vm.tf
+++ b/workloads/wordpress-vm/wordpress-vm.tf
@@ -1,0 +1,140 @@
+provider "azurerm" {
+    features {}
+}
+
+resource "azurerm_resource_group" "example" {
+    name     = "example-resources"
+    location = "eastus"
+}
+
+resource "azurerm_virtual_network" "example" {
+    name                = "example-network"
+    address_space       = ["10.0.0.0/16"]
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_subnet" "example" {
+    name                 = "example-subnet"
+    resource_group_name  = azurerm_resource_group.example.name
+    virtual_network_name = azurerm_virtual_network.example.name
+    address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_public_ip" "example" {
+    name                = "example-public-ip"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+    allocation_method   = "Dynamic"
+}
+
+resource "azurerm_network_security_group" "example" {
+    name                = "example-nsg"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+
+    security_rule {
+        name                       = "HTTP"
+        priority                   = 1001
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "80"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+    }
+
+    security_rule {
+        name                       = "SSH"
+        priority                   = 1002
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "22"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+    }
+}
+
+resource "azurerm_network_interface" "example" {
+    name                = "example-nic"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+
+    ip_configuration {
+        name                          = "internal"
+        subnet_id                     = azurerm_subnet.example.id
+        private_ip_address_allocation = "Dynamic"
+        public_ip_address_id          = azurerm_public_ip.example.id
+    }
+}
+
+resource "azurerm_linux_virtual_machine" "example" {
+    name                = "example-vm"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+
+    size                 = "Standard_B1s"
+    admin_username       = "adminuser"
+    network_interface_ids = [azurerm_network_interface.example.id]
+
+    source_image_reference {
+        publisher = "Canonical"
+        offer     = "UbuntuServer"
+        sku       = "18.04-LTS"
+        version   = "latest"
+    }
+
+    os_disk {
+        name              = "example-os-disk"
+        caching           = "ReadWrite"
+        storage_account_type = "Standard_LRS"
+    }
+
+    computer_name  = "examplevm"
+    admin_password = "Password1234!"
+
+    custom_data = <<-EOF
+                                #!/bin/bash
+                                sudo apt-get update
+                                sudo apt-get install -y apache2 mysql-server php libapache2-mod-php php-mysql
+                                EOF
+}
+
+resource "azurerm_mysql_server" "example" {
+    name                = "example-mysql-server"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+    sku_name            = "B_Gen5_1"
+    storage_mb          = 5120
+    version             = "5.7"
+    administrator_login          = "mysqladmin"
+    administrator_login_password = "Password1234!"
+}
+
+resource "azurerm_app_service_plan" "example" {
+    name                = "example-app-service-plan"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+    sku {
+        tier = "Standard"
+        size = "S1"
+    }
+}
+
+resource "azurerm_app_service" "example" {
+    name                = "example-app-service"
+    location            = azurerm_resource_group.example.location
+    resource_group_name = azurerm_resource_group.example.name
+    app_service_plan_id = azurerm_app_service_plan.example.id
+    site_config {
+        linux_fx_version = "DOCKER|wordpress"
+        app_settings = {
+            WORDPRESS_DB_HOST     = azurerm_mysql_server.example.fully_qualified_domain_name
+            WORDPRESS_DB_USER     = azurerm_mysql_server.example.administrator_login
+            WORDPRESS_DB_PASSWORD = azurerm_mysql_server.example.administrator_login_password
+        }
+    }
+}

--- a/workloads/workloads.json
+++ b/workloads/workloads.json
@@ -31,5 +31,96 @@
             "How to deploy LAMP stack on Azure VM",
             "LAMP stack using Azure VM"
         ]
+    },
+    {
+        "title": "Scalable WordPress using Azure VM",
+        "id": "wordpress-vm",
+        "description": "WordPress is a popular content management system (CMS) that allows users to create and manage websites and blogs. It provides a user-friendly interface, a wide range of themes and plugins, and powerful customization options. With WordPress, you can easily publish and update content, manage user roles and permissions, and optimize your website for search engines.",
+        "author": "Microsoft",
+        "source": "https://github.com/Azure/solution-center/tree/dev/workloads/wordpress-vm",
+        "tags": [
+            "Wordpress",
+            "Azure",
+            "VM",
+            "Linux",
+            "Agw",
+            "Bicep",
+            "PHP",
+            "JavaScript"
+        ],
+        "deploymentOptions": [
+            "Arm Template",
+            "Terraform Script",
+            "Bicep Script",
+            "CLI Script",
+            "OneClick",
+            "LearnMode"
+        ],
+        "products": [
+            "Azure VM"
+        ],
+        "sampleQueries": [
+            "How to deploy Wordpress on Azure VM",
+            "Wordpress using Azure VM",
+            "Scalable Wordpress using Azure VM"
+        ]
+    },
+    {
+        "title": "VM Starter Kit Linux",
+        "id": "vm-starter-kit-linux",
+        "description": "This solution provides a starter kit for deploying a Linux virtual machine (VM) in Azure. It includes a set of ARM templates and scripts that can be used to deploy a VM with a variety of configurations, including different sizes, operating systems, and storage options.",
+        "author": "Microsoft",
+        "source": "https://github.com/Azure/solution-center/tree/dev/workloads/vm-starter-kit-linux",
+        "tags": [
+            "VM",
+            "Azure",
+            "Linux",
+            "ARM",
+            "Bastion"
+        ],
+        "deploymentOptions": [
+            "Arm Template",
+            "Terraform Script",
+            "Bicep Script",
+            "CLI Script",
+            "OneClick",
+            "LearnMode"
+        ],
+        "products": [
+            "Azure VM"
+        ],
+        "sampleQueries": [
+            "How to deploy a Linux VM in Azure",
+            "VM Starter Kit for Linux"
+        ]
+    },
+    {
+        "title": "VM Starter Kit Windows",
+        "id": "vm-starter-kit-windows",
+        "description": "This solution provides a starter kit for deploying a Windows virtual machine (VM) in Azure. It includes a set of ARM templates and scripts that can be used to deploy a VM with a variety of configurations, including different sizes, operating systems, and storage options.",
+        "author": "Microsoft",
+        "source": "https://github.com/Azure/solution-center/tree/dev/workloads/vm-starter-kit-windowa",
+        "tags": [
+            "VM",
+            "Azure",
+            "Windows",
+            "ARM",
+            "Bastion"
+        ],
+        "deploymentOptions": [
+            "Arm Template",
+            "Terraform Script",
+            "Bicep Script",
+            "CLI Script",
+            "OneClick",
+            "LearnMode"
+        ],
+        "products": [
+            "Azure VM"
+        ],
+        "sampleQueries": [
+            "How to deploy a Windows VM in Azure",
+            "VM Starter Kit for Windows"
+        ]
     }
 ]


### PR DESCRIPTION
Added three new folder under workloads: Wordpress-vm, Vm-starter-kit-windows, and Vm-starter-kit-linux.

Each folder contains arm, bicep, ps1, and tf scripts to deploy their corresponding workloads. 